### PR TITLE
Use ID from configuration

### DIFF
--- a/pingdom_rum.php
+++ b/pingdom_rum.php
@@ -24,7 +24,7 @@ class Pingdom_RUMPlugin extends Plugin
         $prumid = trim($this->config->get('plugins.pingdom_rum.prumid'));
         if ($prumid) {
             $gsjs = <<<PingdomRUMJS
-var _prum = [['id', '5519be67abe53d310131abbc'],
+var _prum = [['id', '$prumid'],
             ['mark', 'firstbyte', (new Date()).getTime()]];
         (function() {
             var s = document.getElementsByTagName('script')[0]


### PR DESCRIPTION
Updated the JavaScript code snippet to use the configured $prumid (instead of hardcoded id value).

Original file ignore configuration ID and always rendered original static ID to page. With this change, the rendered snippet will use the configured value.

Thanks for creating this plugin. Hope this update helps.